### PR TITLE
Update the package to use generics

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -1,15 +1,15 @@
 package hamt
 
-type bucket []Entry
+type bucket[T Entry[T]] []T
 
-func newBucket() bucket {
-	return bucket(nil)
+func newBucket[T Entry[T]]() bucket[T] {
+	return bucket[T](nil)
 }
 
-func (b bucket) Insert(e Entry) node {
+func (b bucket[T]) Insert(e T) node[T] {
 	for i, f := range b {
 		if e.Equal(f) {
-			new := make(bucket, len(b))
+			new := make(bucket[T], len(b))
 			copy(new, b)
 			new[i] = e
 			return new
@@ -19,17 +19,17 @@ func (b bucket) Insert(e Entry) node {
 	return append(b, e)
 }
 
-func (b bucket) Find(e Entry) Entry {
+func (b bucket[T]) Find(e T) *T {
 	for _, f := range b {
 		if e.Equal(f) {
-			return f
+			return &f
 		}
 	}
 
 	return nil
 }
 
-func (b bucket) Delete(e Entry) (node, bool) {
+func (b bucket[T]) Delete(e T) (node[T], bool) {
 	for i, f := range b {
 		if e.Equal(f) {
 			return append(b[:i], b[i+1:]...), true
@@ -39,15 +39,15 @@ func (b bucket) Delete(e Entry) (node, bool) {
 	return b, false
 }
 
-func (b bucket) FirstRest() (Entry, node) {
+func (b bucket[T]) FirstRest() (*T, node[T]) {
 	if len(b) == 0 {
 		return nil, b
 	}
 
-	return b[0], b[1:]
+	return &b[0], b[1:]
 }
 
-func (b bucket) ForEach(cb func(Entry) error) error {
+func (b bucket[T]) ForEach(cb func(T) error) error {
 	for _, e := range b {
 		if err := cb(e); err != nil {
 			return err
@@ -56,7 +56,7 @@ func (b bucket) ForEach(cb func(Entry) error) error {
 	return nil
 }
 
-func (b bucket) State() nodeState {
+func (b bucket[T]) State() nodeState {
 	switch len(b) {
 	case 0:
 		return empty
@@ -67,6 +67,6 @@ func (b bucket) State() nodeState {
 	return more
 }
 
-func (b bucket) Size() int {
+func (b bucket[T]) Size() int {
 	return len(b)
 }

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -7,84 +7,84 @@ import (
 )
 
 func TestNewBucket(t *testing.T) {
-	b := newBucket()
+	b := newBucket[entryInt]()
 
 	assert.Equal(t, 0, b.Size())
 }
 
 func TestBucketInsert(t *testing.T) {
-	b := newBucket().Insert(entryInt(42))
+	b := newBucket[entryInt]().Insert(entryInt(42))
 
 	assert.Equal(t, 1, b.Size())
-	assert.Equal(t, entryInt(42), b.Find(entryInt(42)))
+	assert.Equal(t, entryInt(42), *b.Find(entryInt(42)))
 
 	b = b.Insert(entryInt(42))
 
 	assert.Equal(t, 1, b.Size())
-	assert.Equal(t, entryInt(42), b.Find(entryInt(42)))
+	assert.Equal(t, entryInt(42), *b.Find(entryInt(42)))
 
 	b = b.Insert(entryInt(2049))
 
 	assert.Equal(t, 2, b.Size())
-	assert.Equal(t, entryInt(42), b.Find(entryInt(42)))
-	assert.Equal(t, entryInt(2049), b.Find(entryInt(2049)))
+	assert.Equal(t, entryInt(42), *b.Find(entryInt(42)))
+	assert.Equal(t, entryInt(2049), *b.Find(entryInt(2049)))
 
 	b = b.Insert(entryInt(2049))
 
 	assert.Equal(t, 2, b.Size())
-	assert.Equal(t, entryInt(42), b.Find(entryInt(42)))
-	assert.Equal(t, entryInt(2049), b.Find(entryInt(2049)))
+	assert.Equal(t, entryInt(42), *b.Find(entryInt(42)))
+	assert.Equal(t, entryInt(2049), *b.Find(entryInt(2049)))
 }
 
 func TestBucketInsertAsMap(t *testing.T) {
 	kv := newTestKeyValue(0, "foo")
-	b := newBucket().Insert(kv)
+	b := newBucket[keyValue[entryInt, string]]().Insert(kv)
 
 	assert.Equal(t, 1, b.Size())
-	assert.EqualValues(t, kv, b.Find(kv))
+	assert.EqualValues(t, kv, *b.Find(kv))
 
 	new := newTestKeyValue(0, "bar")
 	b = b.Insert(new)
 
 	assert.Equal(t, 1, b.Size())
-	assert.EqualValues(t, new, b.Find(kv))
+	assert.EqualValues(t, new, *b.Find(kv))
 }
 
 func TestBucketDelete(t *testing.T) {
-	b, changed := newBucket().Insert(entryInt(42)).Delete(entryInt(42))
+	b, changed := newBucket[entryInt]().Insert(entryInt(42)).Delete(entryInt(42))
 
 	assert.True(t, changed)
 	assert.Equal(t, 0, b.Size())
-	assert.Equal(t, nil, b.Find(entryInt(42)))
+	assert.Nil(t, b.Find(entryInt(42)))
 }
 
 func TestBucketDeleteNonExistentEntries(t *testing.T) {
-	b, changed := newBucket().Delete(entryInt(42))
+	b, changed := newBucket[entryInt]().Delete(entryInt(42))
 
 	assert.False(t, changed)
 	assert.Equal(t, 0, b.Size())
 
-	b, changed = newBucket().Insert(entryInt(42)).Delete(entryInt(2049))
+	b, changed = newBucket[entryInt]().Insert(entryInt(42)).Delete(entryInt(2049))
 
 	assert.False(t, changed)
 	assert.Equal(t, 1, b.Size())
-	assert.Equal(t, entryInt(42), b.Find(entryInt(42)))
+	assert.Equal(t, entryInt(42), *b.Find(entryInt(42)))
 }
 
 func TestBucketFind(t *testing.T) {
-	assert.Equal(t, nil, newBucket().Find(entryInt(42)))
+	assert.Nil(t, newBucket[entryInt]().Find(entryInt(42)))
 }
 
 func TestBucketFirstRest(t *testing.T) {
-	e, b := newBucket().FirstRest()
+	e, b := newBucket[entryInt]().FirstRest()
 
-	assert.Equal(t, nil, e)
+	assert.Nil(t, e)
 	assert.Equal(t, 0, b.Size())
 
 	b = b.Insert(entryInt(42))
 	e, r := b.FirstRest()
 
-	assert.Equal(t, entryInt(42), e)
+	assert.Equal(t, entryInt(42), *e)
 	assert.Equal(t, 0, r.Size())
 
 	b = b.Insert(entryInt(2049))
@@ -99,7 +99,7 @@ func TestBucketFirstRest(t *testing.T) {
 }
 
 func TestBucketState(t *testing.T) {
-	var b node = newBucket()
+	var b node[entryInt] = newBucket[entryInt]()
 
 	assert.Equal(t, empty, b.State())
 

--- a/entry.go
+++ b/entry.go
@@ -1,7 +1,8 @@
 package hamt
 
-// Entry represents an entry in a collection.
-type Entry interface {
+// Entry represents an entry in a collection, which can be compared to values of
+// type T (which is typically also the underlying type of the Entry).
+type Entry[T any] interface {
 	Hash() uint32
-	Equal(Entry) bool
+	Equal(T) bool
 }

--- a/entry_test.go
+++ b/entry_test.go
@@ -12,20 +12,14 @@ func (i entryInt) Hash() uint32 {
 	return uint32(i)
 }
 
-func (i entryInt) Equal(e Entry) bool {
-	j, ok := e.(entryInt)
-
-	if !ok {
-		return false
-	}
-
+func (i entryInt) Equal(j entryInt) bool {
 	return i == j
 }
 
 func TestEntry(t *testing.T) {
-	t.Log(Entry(entryInt(42)))
+	t.Log(Entry[entryInt](entryInt(42)))
 }
 
 func TestEntryKey(t *testing.T) {
-	assert.Equal(t, uint32(42), Entry(entryInt(42)).Hash())
+	assert.Equal(t, uint32(42), entryInt(42).Hash())
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/raviqqe/hamt
 
-go 1.15
+go 1.18
 
 require github.com/stretchr/testify v1.8.1

--- a/key_value.go
+++ b/key_value.go
@@ -1,22 +1,18 @@
 package hamt
 
-type keyValue struct {
-	key   Entry
-	value interface{}
+type keyValue[K Entry[K], V any] struct {
+	key   K
+	value V
 }
 
-func newKeyValue(k Entry, v interface{}) keyValue {
-	return keyValue{k, v}
+func newKeyValue[K Entry[K], V any](k K, v V) keyValue[K, V] {
+	return keyValue[K, V]{k, v}
 }
 
-func (kv keyValue) Hash() uint32 {
+func (kv keyValue[K, V]) Hash() uint32 {
 	return kv.key.Hash()
 }
 
-func (kv keyValue) Equal(e Entry) bool {
-	if k, ok := e.(keyValue); ok {
-		e = k.key
-	}
-
-	return kv.key.Equal(e)
+func (kv keyValue[K, V]) Equal(e keyValue[K, V]) bool {
+	return kv.key.Equal(e.key)
 }

--- a/key_value_test.go
+++ b/key_value_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func newTestKeyValue(k uint32, v string) Entry {
+func newTestKeyValue(k uint32, v string) keyValue[entryInt, string] {
 	return newKeyValue(entryInt(k), v)
 }
 
@@ -15,7 +15,7 @@ func TestNewKeyValue(t *testing.T) {
 }
 
 func TestKeyValueAsEntry(t *testing.T) {
-	t.Log(Entry(newKeyValue(entryInt(42), "value")))
+	t.Log(Entry[keyValue[entryInt, string]](newKeyValue(entryInt(42), "value")))
 }
 
 func TestKeyValueHash(t *testing.T) {
@@ -27,7 +27,7 @@ func TestKeyValueEqual(t *testing.T) {
 	kv := newKeyValue(k, "value")
 
 	assert.True(t, kv.Equal(kv))
-	assert.True(t, kv.Equal(k))
+	assert.True(t, kv.key.Equal(k))
 	assert.False(t, kv.Equal(newKeyValue(entryInt(2049), "value")))
-	assert.False(t, kv.Equal(entryInt(2049)))
+	assert.False(t, kv.key.Equal(entryInt(2049)))
 }

--- a/map.go
+++ b/map.go
@@ -1,71 +1,71 @@
 package hamt
 
 // Map represents a map (associative array).
-type Map struct {
-	set Set
+type Map[K Entry[K], V any] struct {
+	set Set[keyValue[K, V]]
 }
 
 // NewMap creates a new map.
-func NewMap() Map {
-	return Map{NewSet()}
+func NewMap[K Entry[K], V any]() Map[K, V] {
+	return Map[K, V]{NewSet[keyValue[K, V]]()}
 }
 
 // Insert inserts a key-value pair into a map.
-func (m Map) Insert(k Entry, v interface{}) Map {
-	return Map{m.set.Insert(newKeyValue(k, v))}
+func (m Map[K, V]) Insert(k K, v V) Map[K, V] {
+	return Map[K, V]{m.set.Insert(newKeyValue(k, v))}
 }
 
 // Delete deletes a pair of a key and a value from a map.
-func (m Map) Delete(k Entry) Map {
-	return Map{m.set.Delete(k)}
+func (m Map[K, V]) Delete(k K) Map[K, V] {
+	var zero V
+	return Map[K, V]{m.set.Delete(newKeyValue(k, zero))}
 }
 
 // Find finds a value corresponding to a given key from a map.
 // It returns nil if no value is found.
-func (m Map) Find(k Entry) interface{} {
-	e := m.set.find(k)
+func (m Map[K, V]) Find(k K) *V {
+	var zero V
+	e := m.set.find(newKeyValue(k, zero))
 
 	if e == nil {
 		return nil
 	}
 
-	return e.(keyValue).value
+	return &e.value
 }
 
 // Include returns true if a key-value pair corresponding with a given key is
 // included in a map, or false otherwise.
-func (m Map) Include(k Entry) bool {
+func (m Map[K, V]) Include(k K) bool {
 	return m.Find(k) != nil
 }
 
 // FirstRest returns a key-value pair in a map and a rest of the map.
 // This method is useful for iteration.
 // The key and value would be nil if the map is empty.
-func (m Map) FirstRest() (Entry, interface{}, Map) {
+func (m Map[K, V]) FirstRest() (*K, *V, Map[K, V]) {
 	e, s := m.set.FirstRest()
-	m = Map{s}
+	m = Map[K, V]{s}
 
 	if e == nil {
 		return nil, nil, m
 	}
 
-	kv := e.(keyValue)
-	return kv.key, kv.value, m
+	return &e.key, &e.value, m
 }
 
-func (m Map) ForEach(cb func(Entry, interface{}) error) error {
-	return m.set.ForEach(func(e Entry) error {
-		kv := e.(keyValue)
+func (m Map[K, V]) ForEach(cb func(K, V) error) error {
+	return m.set.ForEach(func(kv keyValue[K, V]) error {
 		return cb(kv.key, kv.value)
 	})
 }
 
 // Merge merges 2 maps into one.
-func (m Map) Merge(n Map) Map {
-	return Map{m.set.Merge(n.set)}
+func (m Map[K, V]) Merge(n Map[K, V]) Map[K, V] {
+	return Map[K, V]{m.set.Merge(n.set)}
 }
 
 // Size returns a size of a map.
-func (m Map) Size() int {
+func (m Map[K, V]) Size() int {
 	return m.set.Size()
 }

--- a/map_test.go
+++ b/map_test.go
@@ -8,30 +8,30 @@ import (
 )
 
 func TestNewMap(t *testing.T) {
-	NewMap()
+	NewMap[entryInt, string]()
 }
 
 func TestMapInsert(t *testing.T) {
-	m := NewMap()
+	m := NewMap[entryInt, string]()
 
 	for i := 0; i < iterations; i++ {
 		e := entryInt(rand.Int31())
 		m = m.Insert(e, "value")
-		assert.Equal(t, "value", m.Find(e))
+		assert.Equal(t, "value", *m.Find(e))
 	}
 }
 
 func TestMapOperations(t *testing.T) {
-	m := NewMap()
+	m := NewMap[entryInt, string]()
 
 	for i := 0; i < iterations; i++ {
 		k := entryInt(rand.Int31() % 256)
-		var mm Map
+		var mm Map[entryInt, string]
 
 		if rand.Int()%2 == 0 {
 			mm = m.Insert(k, "value")
 
-			assert.Equal(t, "value", mm.Find(k))
+			assert.Equal(t, "value", *mm.Find(k))
 
 			if m.Include(k) {
 				assert.Equal(t, m.Size(), mm.Size())
@@ -41,7 +41,7 @@ func TestMapOperations(t *testing.T) {
 		} else {
 			mm = m.Delete(k)
 
-			assert.Equal(t, nil, mm.Find(k))
+			assert.Nil(t, mm.Find(k))
 
 			if m.Include(k) {
 				assert.Equal(t, m.Size()-1, mm.Size())
@@ -55,18 +55,18 @@ func TestMapOperations(t *testing.T) {
 }
 
 func TestMapFirstRest(t *testing.T) {
-	m := NewMap()
+	m := NewMap[entryInt, string]()
 	k, v, mm := m.FirstRest()
 
-	assert.Equal(t, nil, k)
-	assert.Equal(t, nil, v)
+	assert.Nil(t, k)
+	assert.Nil(t, v)
 	assert.Equal(t, 0, mm.Size())
 
 	m = m.Insert(entryInt(42), "value")
 	k, v, mm = m.FirstRest()
 
-	assert.Equal(t, entryInt(42), k)
-	assert.Equal(t, "value", v)
+	assert.Equal(t, entryInt(42), *k)
+	assert.Equal(t, "value", *v)
 	assert.Equal(t, 0, mm.Size())
 
 	m = m.Insert(entryInt(2049), "value")
@@ -75,30 +75,30 @@ func TestMapFirstRest(t *testing.T) {
 	for i := 0; i < s; i++ {
 		k, v, m = m.FirstRest()
 
-		assert.NotEqual(t, nil, k)
-		assert.Equal(t, "value", v)
+		assert.NotNil(t, k)
+		assert.Equal(t, "value", *v)
 		assert.Equal(t, 1-i, m.Size())
 	}
 }
 
 func TestMapForEach(t *testing.T) {
-	m := NewMap()
-	err := m.ForEach(func(key Entry, val interface{}) error {
+	m := NewMap[entryInt, string]()
+	err := m.ForEach(func(key entryInt, val string) error {
 		assert.Fail(t, "for-each callback called on empty set")
 		return nil
 	})
 	assert.NoError(t, err)
 
 	m = m.Insert(entryInt(42), "value")
-	kvs := make([]keyValue, 0)
-	want := []keyValue{
+	kvs := make([]keyValue[entryInt, string], 0)
+	want := []keyValue[entryInt, string]{
 		{
 			key:   entryInt(42),
 			value: "value",
 		},
 	}
-	err = m.ForEach(func(key Entry, val interface{}) error {
-		kvs = append(kvs, keyValue{
+	err = m.ForEach(func(key entryInt, val string) error {
+		kvs = append(kvs, keyValue[entryInt, string]{
 			key:   key,
 			value: val,
 		})
@@ -108,8 +108,8 @@ func TestMapForEach(t *testing.T) {
 	assert.Equal(t, want, kvs)
 
 	m = m.Insert(entryInt(2049), "value2")
-	kvs = make([]keyValue, 0)
-	want = []keyValue{
+	kvs = make([]keyValue[entryInt, string], 0)
+	want = []keyValue[entryInt, string]{
 		{
 			key:   entryInt(42),
 			value: "value",
@@ -119,8 +119,8 @@ func TestMapForEach(t *testing.T) {
 			value: "value2",
 		},
 	}
-	err = m.ForEach(func(key Entry, val interface{}) error {
-		kvs = append(kvs, keyValue{
+	err = m.ForEach(func(key entryInt, val string) error {
+		kvs = append(kvs, keyValue[entryInt, string]{
 			key:   key,
 			value: val,
 		})
@@ -131,31 +131,31 @@ func TestMapForEach(t *testing.T) {
 }
 
 func TestMapMerge(t *testing.T) {
-	for _, ms := range [][3]Map{
+	for _, ms := range [][3]Map[entryInt, string]{
 		{
-			NewMap(),
-			NewMap(),
-			NewMap(),
+			NewMap[entryInt, string](),
+			NewMap[entryInt, string](),
+			NewMap[entryInt, string](),
 		},
 		{
-			NewMap().Insert(entryInt(1), "foo"),
-			NewMap(),
-			NewMap().Insert(entryInt(1), "foo"),
+			NewMap[entryInt, string]().Insert(entryInt(1), "foo"),
+			NewMap[entryInt, string](),
+			NewMap[entryInt, string]().Insert(entryInt(1), "foo"),
 		},
 		{
-			NewMap(),
-			NewMap().Insert(entryInt(1), "foo"),
-			NewMap().Insert(entryInt(1), "foo"),
+			NewMap[entryInt, string](),
+			NewMap[entryInt, string]().Insert(entryInt(1), "foo"),
+			NewMap[entryInt, string]().Insert(entryInt(1), "foo"),
 		},
 		{
-			NewMap().Insert(entryInt(2), "foo"),
-			NewMap().Insert(entryInt(1), "foo"),
-			NewMap().Insert(entryInt(1), "foo").Insert(entryInt(2), "foo")},
+			NewMap[entryInt, string]().Insert(entryInt(2), "foo"),
+			NewMap[entryInt, string]().Insert(entryInt(1), "foo"),
+			NewMap[entryInt, string]().Insert(entryInt(1), "foo").Insert(entryInt(2), "foo")},
 	} {
 		assert.Equal(t, ms[2], ms[0].Merge(ms[1]))
 	}
 }
 
 func TestMapSize(t *testing.T) {
-	assert.Equal(t, 0, NewMap().Size())
+	assert.Equal(t, 0, NewMap[entryInt, string]().Size())
 }

--- a/node.go
+++ b/node.go
@@ -9,12 +9,12 @@ const (
 )
 
 // node represents a node in a HAMT.
-type node interface {
-	Insert(Entry) node
-	Delete(Entry) (node, bool)
-	Find(Entry) Entry
-	FirstRest() (Entry, node)
-	ForEach(func(Entry) error) error
+type node[T Entry[T]] interface {
+	Insert(T) node[T]
+	Delete(T) (node[T], bool)
+	Find(T) *T
+	FirstRest() (*T, node[T])
+	ForEach(func(T) error) error
 	State() nodeState
 	Size() int // for debugging
 }

--- a/node_test.go
+++ b/node_test.go
@@ -3,9 +3,9 @@ package hamt
 import "testing"
 
 func TestHamtAsNode(t *testing.T) {
-	t.Log(node(newHamt(0)))
+	t.Log(node[entryInt](newHamt[entryInt](0)))
 }
 
 func TestBucketAsNode(t *testing.T) {
-	t.Log(node(newBucket()))
+	t.Log(node[entryInt](newBucket[entryInt]()))
 }

--- a/set.go
+++ b/set.go
@@ -1,29 +1,29 @@
 package hamt
 
 // Set represents a set.
-type Set struct {
+type Set[T Entry[T]] struct {
 	size int
-	hamt hamt
+	hamt hamt[T]
 }
 
 // NewSet creates a new set.
-func NewSet() Set {
-	return Set{0, newHamt(0)}
+func NewSet[T Entry[T]]() Set[T] {
+	return Set[T]{0, newHamt[T](0)}
 }
 
 // Insert inserts a value into a set.
-func (s Set) Insert(e Entry) Set {
+func (s Set[T]) Insert(e T) Set[T] {
 	size := s.size
 
 	if s.find(e) == nil {
 		size++
 	}
 
-	return Set{size, s.hamt.Insert(e).(hamt)}
+	return Set[T]{size, s.hamt.Insert(e).(hamt[T])}
 }
 
 // Delete deletes a value from a set.
-func (s Set) Delete(e Entry) Set {
+func (s Set[T]) Delete(e T) Set[T] {
 	n, b := s.hamt.Delete(e)
 	size := s.size
 
@@ -31,21 +31,21 @@ func (s Set) Delete(e Entry) Set {
 		size--
 	}
 
-	return Set{size, n.(hamt)}
+	return Set[T]{size, n.(hamt[T])}
 }
 
-func (s Set) find(e Entry) Entry {
+func (s Set[T]) find(e T) *T {
 	return s.hamt.Find(e)
 }
 
 // Include returns true if a given entry is included in a set, or false otherwise.
-func (s Set) Include(e Entry) bool {
+func (s Set[T]) Include(e T) bool {
 	return s.find(e) != nil
 }
 
-// FirstRest returns a value in a set and a rest of the set.
+// FirstRest returns a pointer to a value in a set and a rest of the set.
 // This method is useful for iteration.
-func (s Set) FirstRest() (Entry, Set) {
+func (s Set[T]) FirstRest() (*T, Set[T]) {
 	e, n := s.hamt.FirstRest()
 	size := s.size
 
@@ -53,25 +53,25 @@ func (s Set) FirstRest() (Entry, Set) {
 		size--
 	}
 
-	return e, Set{size, n.(hamt)}
+	return e, Set[T]{size, n.(hamt[T])}
 }
 
-func (s Set) ForEach(cb func(Entry) error) error {
+func (s Set[T]) ForEach(cb func(T) error) error {
 	return s.hamt.ForEach(cb)
 }
 
 // Merge merges 2 sets into one.
-func (s Set) Merge(t Set) Set {
+func (s Set[T]) Merge(t Set[T]) Set[T] {
 	for t.Size() != 0 {
-		var e Entry
+		var e *T
 		e, t = t.FirstRest()
-		s = s.Insert(e)
+		s = s.Insert(*e)
 	}
 
 	return s
 }
 
 // Size returns a size of a set.
-func (s Set) Size() int {
+func (s Set[T]) Size() int {
 	return s.size
 }

--- a/set_test.go
+++ b/set_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func TestNewSet(t *testing.T) {
-	NewSet()
+	NewSet[entryInt]()
 }
 
 func TestSetInsert(t *testing.T) {
-	s := NewSet()
+	s := NewSet[entryInt]()
 
 	for i := 0; i < iterations; i++ {
 		e := entryInt(rand.Int31())
@@ -22,13 +22,13 @@ func TestSetInsert(t *testing.T) {
 }
 
 func TestSetOperations(t *testing.T) {
-	s := NewSet()
+	s := NewSet[entryInt]()
 
 	for i := 0; i < iterations; i++ {
 		assert.Equal(t, s.hamt.Size(), s.Size())
 
 		e := entryInt(rand.Int31() % 256)
-		var ss Set
+		var ss Set[entryInt]
 
 		if rand.Int()%2 == 0 {
 			ss = s.Insert(e)
@@ -57,16 +57,16 @@ func TestSetOperations(t *testing.T) {
 }
 
 func TestSetFirstRest(t *testing.T) {
-	s := NewSet()
+	s := NewSet[entryInt]()
 	e, ss := s.FirstRest()
 
-	assert.Equal(t, nil, e)
+	assert.Nil(t, e)
 	assert.Equal(t, 0, ss.Size())
 
 	s = s.Insert(entryInt(42))
 	e, ss = s.FirstRest()
 
-	assert.Equal(t, entryInt(42), e)
+	assert.Equal(t, entryInt(42), *e)
 	assert.Equal(t, 0, ss.Size())
 
 	s = s.Insert(entryInt(2049))
@@ -81,8 +81,8 @@ func TestSetFirstRest(t *testing.T) {
 }
 
 func TestSetForEach(t *testing.T) {
-	s := NewSet()
-	err := s.ForEach(func(entry Entry) error {
+	s := NewSet[entryInt]()
+	err := s.ForEach(func(entry entryInt) error {
 		assert.Fail(t, "for-each callback called on empty set")
 		return nil
 	})
@@ -90,8 +90,8 @@ func TestSetForEach(t *testing.T) {
 
 	s = s.Insert(entryInt(42))
 	entries := make([]entryInt, 0)
-	err = s.ForEach(func(entry Entry) error {
-		entries = append(entries, entry.(entryInt))
+	err = s.ForEach(func(entry entryInt) error {
+		entries = append(entries, entry)
 		return nil
 	})
 	assert.NoError(t, err)
@@ -99,8 +99,8 @@ func TestSetForEach(t *testing.T) {
 
 	s = s.Insert(entryInt(2049))
 	entries = make([]entryInt, 0)
-	err = s.ForEach(func(entry Entry) error {
-		entries = append(entries, entry.(entryInt))
+	err = s.ForEach(func(entry entryInt) error {
+		entries = append(entries, entry)
 		return nil
 	})
 	assert.NoError(t, err)
@@ -108,37 +108,37 @@ func TestSetForEach(t *testing.T) {
 }
 
 func TestSetMerge(t *testing.T) {
-	for _, ss := range [][3]Set{
+	for _, ss := range [][3]Set[entryInt]{
 		{
-			NewSet(),
-			NewSet(),
-			NewSet(),
+			NewSet[entryInt](),
+			NewSet[entryInt](),
+			NewSet[entryInt](),
 		},
 		{
-			NewSet().Insert(entryInt(1)),
-			NewSet(),
-			NewSet().Insert(entryInt(1)),
+			NewSet[entryInt]().Insert(entryInt(1)),
+			NewSet[entryInt](),
+			NewSet[entryInt]().Insert(entryInt(1)),
 		},
 		{
-			NewSet(),
-			NewSet().Insert(entryInt(1)),
-			NewSet().Insert(entryInt(1)),
+			NewSet[entryInt](),
+			NewSet[entryInt]().Insert(entryInt(1)),
+			NewSet[entryInt]().Insert(entryInt(1)),
 		},
 		{
-			NewSet().Insert(entryInt(2)),
-			NewSet().Insert(entryInt(1)),
-			NewSet().Insert(entryInt(1)).Insert(entryInt(2))},
+			NewSet[entryInt]().Insert(entryInt(2)),
+			NewSet[entryInt]().Insert(entryInt(1)),
+			NewSet[entryInt]().Insert(entryInt(1)).Insert(entryInt(2))},
 	} {
 		assert.Equal(t, ss[2], ss[0].Merge(ss[1]))
 	}
 }
 
 func TestSetSize(t *testing.T) {
-	assert.Equal(t, 0, NewSet().Size())
+	assert.Equal(t, 0, NewSet[entryInt]().Size())
 }
 
 func BenchmarkSetInsert(b *testing.B) {
-	s := NewSet()
+	s := NewSet[entryInt]()
 
 	b.ResetTimer()
 
@@ -150,7 +150,7 @@ func BenchmarkSetInsert(b *testing.B) {
 }
 
 func BenchmarkSetSize(b *testing.B) {
-	s := NewSet()
+	s := NewSet[entryInt]()
 
 	b.ResetTimer()
 


### PR DESCRIPTION
This patch updates the API to take advantage of the generics support in Go 1.18+. It is a breaking change, so if merged the next release should be 2.0. If you're not interested in this change let me know; I'll fork for my own purposes in that case.

---

Notes:

- The Entry interface now has a type parameter, so that it can talk about its own underlying type.
- Methods which relied on being able to return nil for the entry now return a pointer to the type.
- We now use the any alias instead of interface{} anywhere it was left after adding type parameters.
- In tests, instances of `assert.Equal(t, nil, ...)` have been changed to `assert.Nil(t, ...)`. This is because assert.Equal does not consider the untyped nil constant to be equal to a nil pointer of a particular type; probably it worked before because the other argument was an interface.

Benchmarks are broadly similar. Before:

goos: linux
goarch: amd64
pkg: github.com/raviqqe/hamt
cpu: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
BenchmarkHamtInsert-8               	     195	   6086113 ns/op
BenchmarkHamtDelete-8               	     710	   1626577 ns/op
BenchmarkHamtFirstRestIteration-8   	       1	4049853564 ns/op
BenchmarkHamtForEachIteration-8     	    9024	    112623 ns/op
BenchmarkBuiltinMapForEach-8        	   13258	     87643 ns/op
BenchmarkBuiltinSliceForEach-8      	  496905	      2403 ns/op
BenchmarkSetInsert-8                	     121	  10263234 ns/op
BenchmarkSetSize-8                  	      32	  35424252 ns/op
--- BENCH: BenchmarkSetSize-8
    set_test.go:160: 1
    set_test.go:160: 2
    set_test.go:160: 3
    set_test.go:160: 4
    set_test.go:160: 5
    set_test.go:160: 6
    set_test.go:160: 7
    set_test.go:160: 8
    set_test.go:160: 9
    set_test.go:160: 10
	... [output truncated]
PASS
ok  	github.com/raviqqe/hamt	27.370s

...And after:

goos: linux
goarch: amd64
pkg: github.com/raviqqe/hamt
cpu: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
BenchmarkHamtInsert-8               	     193	   6351027 ns/op
BenchmarkHamtDelete-8               	     733	   1539728 ns/op
BenchmarkHamtFirstRestIteration-8   	       1	4908351503 ns/op
BenchmarkHamtForEachIteration-8     	   15807	     71250 ns/op
BenchmarkBuiltinMapForEach-8        	   13308	     89030 ns/op
BenchmarkBuiltinSliceForEach-8      	  485073	      2444 ns/op
BenchmarkSetInsert-8                	     138	   9306362 ns/op
BenchmarkSetSize-8                  	      37	  30683603 ns/op
--- BENCH: BenchmarkSetSize-8
    set_test.go:160: 1
    set_test.go:160: 2
    set_test.go:160: 3
    set_test.go:160: 4
    set_test.go:160: 5
    set_test.go:160: 6
    set_test.go:160: 7
    set_test.go:160: 8
    set_test.go:160: 9
    set_test.go:160: 10
	... [output truncated]
PASS
ok  	github.com/raviqqe/hamt	30.325s